### PR TITLE
Switch back to default GitHub pages URL

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-polaris.io


### PR DESCRIPTION
# Description

Switching CNAME back to github.io for now until we are ready to deploy with polaris.io

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)