### PR TITLE
Use Gradle version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:${libs.plugins.spotless.get().version}"
     }
 }
 
@@ -50,13 +50,6 @@ subprojects {
     apply plugin: "com.diffplug.spotless"
     apply plugin: "jacoco-report-aggregation"
     apply plugin: "groovy"
-    ext {
-        jacksonVersion = "2.17.2"
-        icebergVersion = "1.5.0"
-        hadoopVersion = "3.3.6"
-        dropwizardVersion = "4.0.7"
-        assertJVersion = "3.25.3"
-    }
 
     tasks.withType(JavaCompile) {
         options.compilerArgs << "-Xlint:unchecked"
@@ -72,17 +65,17 @@ subprojects {
     }
 
     dependencies {
-        implementation(platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}"))
+        implementation(platform(libs.jackson.bom))
         implementation("com.fasterxml.jackson.core:jackson-annotations")
-        implementation("com.google.guava:guava:33.0.0-jre")
-        implementation("org.jetbrains:annotations:24.0.0")
-        implementation("org.slf4j:slf4j-api:2.0.12")
-        compileOnly("com.github.spotbugs:spotbugs-annotations:4.8.5")
+        implementation(libs.guava)
+        implementation(libs.slf4j.api)
+        compileOnly(libs.jetbrains.annotations)
+        compileOnly(libs.spotbugs.annotations)
 
-        testImplementation(platform("org.junit:junit-bom:5.10.3"))
+        testImplementation(platform(libs.junit.bom))
         testImplementation("org.junit.jupiter:junit-jupiter")
-        testImplementation("org.assertj:assertj-core:3.26.3")
-        testImplementation("org.mockito:mockito-core:5.11.0")
+        testImplementation(libs.assertj.core)
+        testImplementation(libs.mockito.core)
 
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }

--- a/extension/persistence/eclipselink/build.gradle
+++ b/extension/persistence/eclipselink/build.gradle
@@ -17,9 +17,10 @@
 dependencies {
     implementation(project(":polaris-core"))
     implementation(project(":polaris-service"))
-    implementation("org.eclipse.persistence:eclipselink:4.0.3")
-    implementation("io.dropwizard:dropwizard-jackson:${dropwizardVersion}")
+    implementation(libs.eclipselink)
+    implementation(platform(libs.dropwizard.bom))
+    implementation("io.dropwizard:dropwizard-jackson")
 
-    testImplementation("com.h2database:h2:2.2.224")
+    testImplementation(libs.h2)
     testImplementation(testFixtures(project(":polaris-core")))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,68 @@
+# Copyright (c) 2024 Snowflake Computing Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[versions]
+hadoop = "3.3.6"
+iceberg = "1.5.0"
+dropwizard = "4.0.7"
+slf4j = "2.0.13"
+swagger = "1.6.14"
+
+[bundles]
+
+
+[libraries]
+assertj-core = { module = "org.assertj:assertj-core", version = "3.26.3" }
+auth0-jwt = { module = "com.auth0:java-jwt", version = "4.2.1" }
+awssdk-bom = { module = "software.amazon.awssdk:bom", version = "2.26.25" }
+azuresdk-bom = { module = "com.azure:azure-sdk-bom", version = "1.2.25" }
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.78" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }
+commons-codec1 = { module = "commons-codec:commons-codec", version = "1.17.0" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.14.0" }
+dropwizard-bom = { module = "io.dropwizard:dropwizard-bom", version = "4.0.7" }
+eclipselink = { module = "org.eclipse.persistence:eclipselink", version = "4.0.3" }
+google-cloud-storage-bom = { module = "com.google.cloud:google-cloud-storage-bom", version = "2.40.1" }
+guava = { module = "com.google.guava:guava", version = "33.2.1-jre" }
+h2 = { module = "com.h2database:h2", version = "2.2.224" }
+hadoop-client-api = { module = "org.apache.hadoop:hadoop-client-api", version.ref = "hadoop" }
+hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
+hadoop-hdfs-client = { module = "org.apache.hadoop:hadoop-hdfs-client", version.ref = "hadoop" }
+iceberg-bom = { module = "org.apache.iceberg:iceberg-bom", version.ref = "iceberg" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.17.2" }
+jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
+jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version = "3.1.0" }
+jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version = "3.1.0" }
+javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version = "1.3.2" }
+javax-inject = { module = "javax.inject:javax.inject", version = "1" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.0" }
+junit-bom = { module = "org.junit:junit-bom", version = "5.10.3" }
+logback-core = { module = "ch.qos.logback:logback-core", version = "1.4.14" }
+micrometer-bom = { module = "io.micrometer:micrometer-bom", version = "1.13.2" }
+mockito-core = { module = "org.mockito:mockito-core", version = "5.11.0" }
+opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version = "1.38.0" }
+opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version = "1.25.0-alpha" }
+prometheus-metrics-exporter-servlet-jakarta = { module = "io.prometheus:prometheus-metrics-exporter-servlet-jakarta", version = "1.3.0" }
+s3mock-testcontainers = { module = "com.adobe.testing:s3mock-testcontainers", version = "3.9.1" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version = "4.8.5" }
+sqllite-jdbc = { module = "org.xerial:sqlite-jdbc", version = "3.45.1.0" }
+swagger-annotations = { module = "io.swagger:swagger-annotations", version.ref = "swagger" }
+swagger-jaxrs = { module = "io.swagger:swagger-jaxrs", version.ref = "swagger" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "1.20.0" }
+
+[plugins]
+openapi-generator = { id = "org.openapi.generator", version = "7.6.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/polaris-core/build.gradle
+++ b/polaris-core/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id "org.openapi.generator" version "7.6.0"
+    alias(libs.plugins.openapi.generator)
     id("java-library")
     id("java-test-fixtures")
 }
@@ -26,9 +26,9 @@ compileJava {
 }
 
 dependencies {
-    implementation(platform("org.apache.iceberg:iceberg-bom:${icebergVersion}"))
-    implementation("org.apache.iceberg:iceberg-api:${icebergVersion}")
-    implementation("org.apache.iceberg:iceberg-core:${icebergVersion}")
+    implementation(platform(libs.iceberg.bom))
+    implementation("org.apache.iceberg:iceberg-api")
+    implementation("org.apache.iceberg:iceberg-core")
     constraints {
         implementation("io.airlift:aircompressor:0.27") {
             because "Vulnerability detected in 0.25"
@@ -36,17 +36,18 @@ dependencies {
     }
     // TODO - this is only here for the Discoverable interface
     // We should use a different mechanism to discover the plugin implementations
-    implementation("io.dropwizard:dropwizard-jackson:${dropwizardVersion}")
+    implementation(platform(libs.dropwizard.bom))
+    implementation("io.dropwizard:dropwizard-jackson")
 
-    implementation(platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}"))
+    implementation(platform(libs.jackson.bom))
     implementation("com.fasterxml.jackson.core:jackson-annotations")
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
-    implementation("org.apache.commons:commons-lang3:3.14.0")
-    implementation("commons-codec:commons-codec:1.17.0")
+    implementation(libs.caffeine)
+    implementation(libs.commons.lang3)
+    implementation(libs.commons.codec1)
 
-    implementation("org.apache.hadoop:hadoop-common:${hadoopVersion}") {
+    implementation(libs.hadoop.common) {
         exclude group: "org.slf4j", module: "slf4j-reload4j"
         exclude group: "org.slf4j", module: "slf4j-log4j12"
         exclude group: "ch.qos.reload4j", module: "reload4j"
@@ -71,24 +72,25 @@ dependencies {
         }
 
     }
-    implementation("org.apache.hadoop:hadoop-hdfs-client:${hadoopVersion}")
+    implementation(libs.hadoop.hdfs.client)
 
-    implementation("javax.inject:javax.inject:1")
-    implementation("io.swagger:swagger-annotations:1.6.14")
-    implementation("io.swagger:swagger-jaxrs:1.6.14")
-    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
+    implementation(libs.javax.inject)
+    implementation(libs.swagger.annotations)
+    implementation(libs.swagger.jaxrs)
+    implementation(libs.jakarta.validation.api)
 
     implementation("org.apache.iceberg:iceberg-aws")
-    implementation(platform("software.amazon.awssdk:bom:2.26.25"))
+    implementation(platform(libs.awssdk.bom))
     implementation("software.amazon.awssdk:sts")
     implementation("software.amazon.awssdk:iam-policy-builder")
     implementation("software.amazon.awssdk:s3")
 
     implementation("org.apache.iceberg:iceberg-azure")
-    implementation("com.azure:azure-storage-blob:12.18.0")
-    implementation("com.azure:azure-storage-common:12.14.2")
-    implementation("com.azure:azure-identity:1.12.2")
-    implementation("com.azure:azure-storage-file-datalake:12.19.0")
+    implementation(platform(libs.azuresdk.bom))
+    implementation("com.azure:azure-storage-blob")
+    implementation("com.azure:azure-storage-common")
+    implementation("com.azure:azure-identity")
+    implementation("com.azure:azure-storage-file-datalake")
     constraints {
         implementation("io.netty:netty-codec-http2:4.1.100") {
             because "Vulnerability detected in 4.1.72"
@@ -99,24 +101,24 @@ dependencies {
     }
 
     implementation("org.apache.iceberg:iceberg-gcp")
-    implementation(platform("com.google.cloud:google-cloud-storage-bom:2.39.0"))
+    implementation(platform(libs.google.cloud.storage.bom))
     implementation("com.google.cloud:google-cloud-storage")
 
-    implementation(platform("io.micrometer:micrometer-bom:1.13.2"))
+    implementation(platform(libs.micrometer.bom))
     implementation("io.micrometer:micrometer-core")
 
-    testFixturesApi(platform("org.junit:junit-bom:5.10.3"))
+    testFixturesApi(platform(libs.junit.bom))
     testFixturesApi("org.junit.jupiter:junit-jupiter")
-    testFixturesApi("org.assertj:assertj-core:3.25.3")
-    testFixturesApi("org.mockito:mockito-core:5.11.0")
+    testFixturesApi(libs.assertj.core)
+    testFixturesApi(libs.mockito.core)
     testFixturesApi("com.fasterxml.jackson.core:jackson-core")
     testFixturesApi("com.fasterxml.jackson.core:jackson-databind")
-    testFixturesApi("org.apache.commons:commons-lang3:3.14.0")
-    testFixturesApi("org.jetbrains:annotations:24.0.0")
-    testFixturesApi(platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}"))
+    testFixturesApi(libs.commons.lang3)
+    testFixturesApi(libs.jetbrains.annotations)
+    testFixturesApi(platform(libs.jackson.bom))
 
-    compileOnly("jakarta.annotation:jakarta.annotation-api:2.1.1")
-    compileOnly("jakarta.persistence:jakarta.persistence-api:3.1.0")
+    compileOnly(libs.jakarta.annotation.api)
+    compileOnly(libs.jakarta.persistence.api)
 }
 
 openApiValidate {

--- a/polaris-service/build.gradle
+++ b/polaris-service/build.gradle
@@ -15,63 +15,65 @@
  */
 
 plugins {
-    id "com.github.johnrengelman.shadow" version "8.1.1"
-    id "org.openapi.generator" version "7.6.0"
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.openapi.generator)
 }
 
 dependencies {
     implementation(project(":polaris-core"))
 
-    implementation(platform("org.apache.iceberg:iceberg-bom:${icebergVersion}"))
+    implementation(platform(libs.iceberg.bom))
     implementation("org.apache.iceberg:iceberg-api")
     implementation("org.apache.iceberg:iceberg-core")
     implementation("org.apache.iceberg:iceberg-aws")
 
-    implementation(platform("io.dropwizard:dropwizard-bom:${dropwizardVersion}"))
+    implementation(platform(libs.dropwizard.bom))
     implementation("io.dropwizard:dropwizard-core")
     implementation("io.dropwizard:dropwizard-auth")
     implementation("io.dropwizard:dropwizard-json-logging")
 
-    implementation(platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}"))
+    implementation(platform(libs.jackson.bom))
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
 
-    implementation(platform("io.opentelemetry:opentelemetry-bom:1.38.0"))
+    implementation(platform(libs.opentelemetry.bom))
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk-trace")
     implementation("io.opentelemetry:opentelemetry-exporter-logging")
-    implementation("io.opentelemetry.semconv:opentelemetry-semconv:1.25.0-alpha")
+    implementation(libs.opentelemetry.semconv)
 
-    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+    implementation(libs.caffeine)
 
-    implementation("io.prometheus:prometheus-metrics-exporter-servlet-jakarta:1.3.0")
-    implementation(platform("io.micrometer:micrometer-bom:1.13.2"))
+    implementation(libs.prometheus.metrics.exporter.servlet.jakarta)
+    implementation(platform(libs.micrometer.bom))
     implementation("io.micrometer:micrometer-core")
     implementation("io.micrometer:micrometer-registry-prometheus")
 
-    implementation("io.swagger:swagger-annotations:1.6.14")
-    implementation("io.swagger:swagger-jaxrs:1.6.14")
-    implementation("javax.annotation:javax.annotation-api:1.3.2")
+    compileOnly(libs.swagger.annotations)
+    implementation(libs.swagger.jaxrs)
+    implementation(libs.javax.annotation.api)
 
-    implementation("org.apache.hadoop:hadoop-client-api:${hadoopVersion}")
+    implementation(libs.hadoop.client.api)
 
-    implementation("org.xerial:sqlite-jdbc:3.45.1.0")
-    implementation("com.auth0:java-jwt:4.2.1")
+    implementation(libs.sqllite.jdbc)
+    implementation(libs.auth0.jwt)
 
-    implementation("ch.qos.logback:logback-core:1.4.14")
-    implementation("org.bouncycastle:bcprov-jdk18on:1.78")
+    implementation(libs.logback.core)
+    implementation(libs.bouncycastle.bcprov)
 
-    implementation("com.google.cloud:google-cloud-storage:2.39.0")
-    implementation(platform("software.amazon.awssdk:bom:2.26.25"))
+    implementation(platform(libs.google.cloud.storage.bom))
+    implementation("com.google.cloud:google-cloud-storage")
+    implementation(platform(libs.awssdk.bom))
     implementation("software.amazon.awssdk:sts")
     implementation("software.amazon.awssdk:sts")
     implementation("software.amazon.awssdk:iam-policy-builder")
     implementation("software.amazon.awssdk:s3")
 
-    testImplementation("org.apache.iceberg:iceberg-api:${icebergVersion}:tests")
-    testImplementation("org.apache.iceberg:iceberg-core:${icebergVersion}:tests")
+    testImplementation("org.apache.iceberg:iceberg-api:${libs.versions.iceberg.get()}:tests")
+    testImplementation("org.apache.iceberg:iceberg-core:${libs.versions.iceberg.get()}:tests")
     testImplementation("io.dropwizard:dropwizard-testing")
-    testImplementation("org.testcontainers:testcontainers:1.19.8")
-    testImplementation("com.adobe.testing:s3mock-testcontainers:3.9.1")
+    testImplementation(platform(libs.testcontainers.bom))
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation(libs.s3mock.testcontainers)
 
     testImplementation("org.apache.iceberg:iceberg-spark-3.5_2.12")
     testImplementation("org.apache.iceberg:iceberg-spark-extensions-3.5_2.12")


### PR DESCRIPTION
# Description

Introduces Gradle version catalogs (toml files), also bump a couple dependencies to recent versions.

Version catalogs as a central place to declare dependencies are easier to manage. Tools like renovate(bot) and dependabot can use these.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
