### PR TITLE
Use toLowerCase(Locale.ROOT) to avoid lowercase capital I

### DIFF
--- a/polaris-core/src/main/java/io/polaris/core/storage/PolarisStorageConfigurationInfo.java
+++ b/polaris-core/src/main/java/io/polaris/core/storage/PolarisStorageConfigurationInfo.java
@@ -32,6 +32,7 @@ import io.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import io.polaris.core.storage.azure.AzureStorageConfigurationInfo;
 import io.polaris.core.storage.gcp.GcpStorageConfigurationInfo;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -187,7 +188,7 @@ public abstract class PolarisStorageConfigurationInfo {
 
   /** Validate if the provided allowed locations are valid for the storage type */
   protected void validatePrefixForStorageType(String loc) {
-    if (!loc.toLowerCase().startsWith(storageType.prefix)) {
+    if (!loc.toLowerCase(Locale.ROOT).startsWith(storageType.prefix)) {
       throw new IllegalArgumentException(
           String.format(
               "Location prefix not allowed: '%s', expected prefix: '%s'", loc, storageType.prefix));


### PR DESCRIPTION
# Description

Tiny fix for users in a Locale which has a lower case Capital I. This would make FILE into fıle.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No tests, this is a pretty common fix. We could run the whole test suite in Turkish but that's probably a waste. 


Please delete options that are not relevant.

- [X ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [X ] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
