### PR TITLE
Force user.language as some tests are locale dependent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ subprojects {
 
     test {
         useJUnitPlatform()
+        jvmArgs += [ '-Duser.language=en' ]
     }
 
     spotless {


### PR DESCRIPTION
# Description

Some tests are locale dependent. For instance `PolarisServiceImplIntegrationTest` is failing if `user.language` is not `en`.

Fixes #11 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR actually fixes the tests when `Locale` is not `US`.

# Checklist:

Please delete options that are not relevant.

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [ ] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
