### PR TITLE
[BUG FIX] CODEOWNERS scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-@polaris-catalog/polaris
+* @polaris-catalog/polaris


### PR DESCRIPTION
# Description

The CODEOWNERS setting is not currently applying correctly on this repository. This change applies a general rule attributing all files in this repo by default to @polaris-catalog/polaris dev team. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

How CODEOWNERS files work is documented [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code