### PR TITLE
Use AssertJ assertions in tests

### DIFF
--- a/polaris-core/src/test/java/io/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/io/polaris/core/persistence/ResolverTest.java
@@ -35,9 +35,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -233,10 +233,10 @@ public class ResolverTest {
         this.resolveDriver(this.cache, "test", null, List.of(N1, N5_N6_T8, N5_N6_T5, N1_N2), null);
     // get all the resolved paths
     List<List<EntityCacheEntry>> resolvedPath = resolver.getResolvedPaths();
-    Assertions.assertEquals(1, resolvedPath.get(0).size());
-    Assertions.assertEquals(2, resolvedPath.get(1).size());
-    Assertions.assertEquals(3, resolvedPath.get(2).size());
-    Assertions.assertEquals(2, resolvedPath.get(3).size());
+    Assertions.assertThat(resolvedPath.get(0)).hasSize(1);
+    Assertions.assertThat(resolvedPath.get(1)).hasSize(2);
+    Assertions.assertThat(resolvedPath.get(2)).hasSize(3);
+    Assertions.assertThat(resolvedPath.get(3)).hasSize(2);
   }
 
   /**
@@ -276,13 +276,13 @@ public class ResolverTest {
     Resolver resolver = this.resolveDriver(this.cache, Set.of("PR2"), "test", Set.of("R2"));
 
     // Now add a new catalog role and see if the changes are reflected
-    Assertions.assertNotNull(resolver.getResolvedReferenceCatalog());
+    Assertions.assertThat(resolver.getResolvedReferenceCatalog()).isNotNull();
     PolarisBaseEntity TEST = resolver.getResolvedReferenceCatalog().getEntity();
     PolarisBaseEntity R3 =
         this.tm.createEntity(List.of(TEST), PolarisEntityType.CATALOG_ROLE, "R3");
 
     // now grant R3 to PR2
-    Assertions.assertEquals(1, resolver.getResolvedCallerPrincipalRoles().size());
+    Assertions.assertThat(resolver.getResolvedCallerPrincipalRoles()).hasSize(1);
     PolarisBaseEntity PR2 = resolver.getResolvedCallerPrincipalRoles().getFirst().getEntity();
     this.tm.grantToGrantee(TEST, R3, PR2, PolarisPrivilege.CATALOG_ROLE_USAGE);
 
@@ -299,7 +299,7 @@ public class ResolverTest {
     resolver = this.resolveDriver(this.cache, Set.of("PR2"), "test", Set.of("R2", "R3"));
 
     // ensure that the correct catalog role was resolved
-    Assertions.assertTrue(resolver.getResolvedCatalogRoles().containsKey(R3_NEW.getId()));
+    Assertions.assertThat(resolver.getResolvedCatalogRoles()).containsKey(R3_NEW.getId());
   }
 
   /** Check resolve paths when cache is inconsistent */
@@ -315,12 +315,12 @@ public class ResolverTest {
     Resolver resolver = this.resolveDriver(this.cache, "test", N1_N2_T1_PATH, null, null);
 
     // get the catalog
-    Assertions.assertNotNull(resolver.getResolvedReferenceCatalog());
+    Assertions.assertThat(resolver.getResolvedReferenceCatalog()).isNotNull();
     PolarisBaseEntity TEST = resolver.getResolvedReferenceCatalog().getEntity();
 
     // get the various entities in the path
-    Assertions.assertNotNull(resolver.getResolvedPath());
-    Assertions.assertEquals(3, resolver.getResolvedPath().size());
+    Assertions.assertThat(resolver.getResolvedPath()).isNotNull();
+    Assertions.assertThat(resolver.getResolvedPath()).hasSize(3);
     PolarisBaseEntity N1 = resolver.getResolvedPath().getFirst().getEntity();
     PolarisBaseEntity N2 = resolver.getResolvedPath().get(1).getEntity();
     PolarisBaseEntity T1 = resolver.getResolvedPath().get(2).getEntity();
@@ -328,8 +328,8 @@ public class ResolverTest {
     // resolve N3
     ResolverPath N1_N3_PATH = new ResolverPath(List.of("N1", "N3"), PolarisEntityType.NAMESPACE);
     resolver = this.resolveDriver(this.cache, "test", N1_N3_PATH, null, null);
-    Assertions.assertNotNull(resolver.getResolvedPath());
-    Assertions.assertEquals(2, resolver.getResolvedPath().size());
+    Assertions.assertThat(resolver.getResolvedPath()).isNotNull();
+    Assertions.assertThat(resolver.getResolvedPath()).hasSize(2);
     PolarisBaseEntity N3 = resolver.getResolvedPath().get(1).getEntity();
 
     // now re-parent T1 under N3, keeping the same name
@@ -468,7 +468,7 @@ public class ResolverTest {
     ResolverStatus status = resolver.resolveAll();
 
     // we expect success
-    Assertions.assertEquals(ResolverStatus.StatusEnum.SUCCESS, status.getStatus());
+    Assertions.assertThat(status.getStatus()).isEqualTo(ResolverStatus.StatusEnum.SUCCESS);
 
     // the principal does not exist, check that this is the case
     if (exists) {
@@ -479,7 +479,8 @@ public class ResolverTest {
           principalName);
     } else {
       // not found
-      Assertions.assertNull(resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName));
+      Assertions.assertThat(resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName))
+          .isNull();
     }
 
     // validate that we were able to resolve the principal and the two principal roles
@@ -489,7 +490,7 @@ public class ResolverTest {
     List<EntityCacheEntry> principalRolesResolved = resolver.getResolvedCallerPrincipalRoles();
 
     // expect two principal roles
-    Assertions.assertEquals(2, principalRolesResolved.size());
+    Assertions.assertThat(principalRolesResolved).hasSize(2);
     principalRolesResolved.sort(Comparator.comparing(p -> p.getEntity().getName()));
 
     // ensure they are PR1 and PR2
@@ -682,8 +683,8 @@ public class ResolverTest {
     ResolverStatus status = resolver.resolveAll();
 
     // we expect success unless a status
-    Assertions.assertNotNull(status);
-    Assertions.assertEquals(expectedStatus, status.getStatus());
+    Assertions.assertThat(status).isNotNull();
+    Assertions.assertThat(status.getStatus()).isEqualTo(expectedStatus);
 
     // validate if status is success
     if (status.getStatus() == ResolverStatus.StatusEnum.SUCCESS) {
@@ -707,10 +708,11 @@ public class ResolverTest {
               principalName);
         } else {
           // principal was optional
-          Assertions.assertTrue(isPrincipalNameOptional);
+          Assertions.assertThat(isPrincipalNameOptional).isTrue();
           // not found
-          Assertions.assertNull(
-              resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName));
+          Assertions.assertThat(
+                  resolver.getResolvedEntity(PolarisEntityType.PRINCIPAL, principalName))
+              .isNull();
         }
       }
 
@@ -736,16 +738,16 @@ public class ResolverTest {
       }
 
       // ensure the right set of principal roles were activated
-      Assertions.assertEquals(expectedSize, principalRolesResolved.size());
+      Assertions.assertThat(principalRolesResolved).hasSize(expectedSize);
 
       // expect either PR1 and PR2
       for (EntityCacheEntry principalRoleResolved : principalRolesResolved) {
-        Assertions.assertNotNull(principalRoleResolved);
-        Assertions.assertNotNull(principalRoleResolved.getEntity());
+        Assertions.assertThat(principalRoleResolved).isNotNull();
+        Assertions.assertThat(principalRoleResolved.getEntity()).isNotNull();
         String roleName = principalRoleResolved.getEntity().getName();
 
         // should be either PR1 or PR2
-        Assertions.assertTrue(roleName.equals("PR1") || roleName.equals("PR2"));
+        Assertions.assertThat(roleName.equals("PR1") || roleName.equals("PR2")).isTrue();
 
         // ensure they are PR1 and PR2
         this.ensureResolved(principalRoleResolved, PolarisEntityType.PRINCIPAL_ROLE, roleName);
@@ -763,7 +765,7 @@ public class ResolverTest {
       if (catalogName != null) {
         EntityCacheEntry catalogEntry =
             resolver.getResolvedEntity(PolarisEntityType.CATALOG, catalogName);
-        Assertions.assertNotNull(catalogEntry);
+        Assertions.assertThat(catalogEntry).isNotNull();
         this.ensureResolved(catalogEntry, PolarisEntityType.CATALOG, catalogName);
 
         // if a catalog role was passed-in, ensure that it was properly resolved
@@ -782,15 +784,15 @@ public class ResolverTest {
 
         // if there is an expected set, ensure we have the same set
         if (expectedActivatedCatalogRoles != null) {
-          Assertions.assertEquals(expectedActivatedCatalogRoles.size(), activatedCatalogs.size());
+          Assertions.assertThat(activatedCatalogs).hasSameSizeAs(expectedActivatedCatalogRoles);
         }
 
         // process each of those
         for (EntityCacheEntry resolvedActivatedCatalogEntry : activatedCatalogs.values()) {
           // must be in the expected list
-          Assertions.assertNotNull(resolvedActivatedCatalogEntry);
+          Assertions.assertThat(resolvedActivatedCatalogEntry).isNotNull();
           PolarisBaseEntity activatedCatalogRole = resolvedActivatedCatalogEntry.getEntity();
-          Assertions.assertNotNull(activatedCatalogRole);
+          Assertions.assertThat(activatedCatalogRole).isNotNull();
           // ensure well resolved
           this.ensureResolved(
               resolvedActivatedCatalogEntry,
@@ -799,9 +801,10 @@ public class ResolverTest {
               activatedCatalogRole.getName());
 
           // in the set of expected catalog roles
-          Assertions.assertTrue(
-              expectedActivatedCatalogRoles == null
-                  || expectedActivatedCatalogRoles.contains(activatedCatalogRole.getName()));
+          Assertions.assertThat(
+                  expectedActivatedCatalogRoles == null
+                      || expectedActivatedCatalogRoles.contains(activatedCatalogRole.getName()))
+              .isTrue();
         }
 
         // resolve each path
@@ -813,7 +816,7 @@ public class ResolverTest {
           List<List<EntityCacheEntry>> allResolvedPaths = resolver.getResolvedPaths();
 
           // same size
-          Assertions.assertEquals(allPathsToCheck.size(), allResolvedPaths.size());
+          Assertions.assertThat(allResolvedPaths).hasSameSizeAs(allPathsToCheck);
 
           // check that each path was properly resolved
           int pathCount = 0;
@@ -844,7 +847,7 @@ public class ResolverTest {
 
     // ensure same cardinality
     if (!pathToResolve.isOptional()) {
-      Assertions.assertEquals(pathToResolve.getEntityNames().size(), resolvedPath.size());
+      Assertions.assertThat(resolvedPath).hasSameSizeAs(pathToResolve.getEntityNames());
     }
 
     // catalog path
@@ -882,17 +885,17 @@ public class ResolverTest {
       PolarisEntityType entityType,
       String entityName) {
     // everything was resolved
-    Assertions.assertNotNull(cacheEntry);
+    Assertions.assertThat(cacheEntry).isNotNull();
     PolarisBaseEntity entity = cacheEntry.getEntity();
-    Assertions.assertNotNull(entity);
+    Assertions.assertThat(entity).isNotNull();
     List<PolarisGrantRecord> grantRecords = cacheEntry.getAllGrantRecords();
-    Assertions.assertNotNull(grantRecords);
+    Assertions.assertThat(grantRecords).isNotNull();
 
     // reference entity cannot be null
     PolarisBaseEntity refEntity =
         this.tm.ensureExistsByName(
             catalogPath, entityType, PolarisEntitySubType.ANY_SUBTYPE, entityName);
-    Assertions.assertNotNull(refEntity);
+    Assertions.assertThat(refEntity).isNotNull();
 
     // reload the cached entry from the backend
     PolarisMetaStoreManager.CachedEntryResult refCachedEntry =
@@ -900,27 +903,27 @@ public class ResolverTest {
             this.callCtx, refEntity.getCatalogId(), refEntity.getId());
 
     // should exist
-    Assertions.assertNotNull(refCachedEntry);
+    Assertions.assertThat(refCachedEntry).isNotNull();
 
     // ensure same entity
     refEntity = refCachedEntry.getEntity();
     List<PolarisGrantRecord> refGrantRecords = refCachedEntry.getEntityGrantRecords();
-    Assertions.assertNotNull(refEntity);
-    Assertions.assertNotNull(refGrantRecords);
-    Assertions.assertEquals(refEntity, entity);
-    Assertions.assertEquals(refEntity.getEntityVersion(), entity.getEntityVersion());
+    Assertions.assertThat(refEntity).isNotNull();
+    Assertions.assertThat(refGrantRecords).isNotNull();
+    Assertions.assertThat(entity).isEqualTo(refEntity);
+    Assertions.assertThat(entity.getEntityVersion()).isEqualTo(refEntity.getEntityVersion());
 
     // ensure it has not been dropped
-    Assertions.assertEquals(0, entity.getDropTimestamp());
+    Assertions.assertThat(entity.getDropTimestamp()).isZero();
 
     // same number of grants
-    Assertions.assertEquals(refGrantRecords.size(), grantRecords.size());
+    Assertions.assertThat(grantRecords).hasSameSizeAs(refGrantRecords);
 
     // ensure same grant records. The order in the list should be deterministic
     Iterator<PolarisGrantRecord> refGrantRecordsIt = refGrantRecords.iterator();
     for (PolarisGrantRecord grantRecord : grantRecords) {
       PolarisGrantRecord refGrantRecord = refGrantRecordsIt.next();
-      Assertions.assertEquals(refGrantRecord, grantRecord);
+      Assertions.assertThat(grantRecord).isEqualTo(refGrantRecord);
     }
   }
 

--- a/polaris-core/src/test/java/io/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/io/polaris/service/storage/azure/AzureCredentialStorageIntegrationTest.java
@@ -48,8 +48,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Strings;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -82,31 +82,31 @@ public class AzureCredentialStorageIntegrationTest {
         Arrays.asList(
             "abfss://container@icebergdfsstorageacct.dfs.core.windows.net/polaris-test/",
             "abfss://container@icebergdfsstorageacct.blob.core.windows.net/polaris-test/");
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () ->
-            subscopedCredsForOperations(
-                differentEndpointList, /* allowedWriteLoc= */ new ArrayList<>(), true));
+    Assertions.assertThatThrownBy(
+            () ->
+                subscopedCredsForOperations(
+                    differentEndpointList, /* allowedWriteLoc= */ new ArrayList<>(), true))
+        .isInstanceOf(RuntimeException.class);
 
     List<String> differentStorageAccts =
         Arrays.asList(
             "abfss://container@polarisadls.dfs.core.windows.net/polaris-test/",
             "abfss://container@icebergdfsstorageacct.dfs.core.windows.net/polaris-test/");
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () ->
-            subscopedCredsForOperations(
-                differentStorageAccts, /* allowedWriteLoc= */ new ArrayList<>(), true));
+    Assertions.assertThatThrownBy(
+            () ->
+                subscopedCredsForOperations(
+                    differentStorageAccts, /* allowedWriteLoc= */ new ArrayList<>(), true))
+        .isInstanceOf(RuntimeException.class);
     List<String> differentContainers =
         Arrays.asList(
             "abfss://container1@icebergdfsstorageacct.dfs.core.windows.net/polaris-test/",
             "abfss://container2@icebergdfsstorageacct.dfs.core.windows.net/polaris-test/");
 
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () ->
-            subscopedCredsForOperations(
-                differentContainers, /* allowedWriteLoc= */ new ArrayList<>(), true));
+    Assertions.assertThatThrownBy(
+            () ->
+                subscopedCredsForOperations(
+                    differentContainers, /* allowedWriteLoc= */ new ArrayList<>(), true))
+        .isInstanceOf(RuntimeException.class);
   }
 
   @TestWithAzureArgs
@@ -126,9 +126,9 @@ public class AzureCredentialStorageIntegrationTest {
             /* allowedReadLoc= */ allowedLoc,
             /* allowedWriteLoc= */ new ArrayList<>(),
             allowListAction);
-    Assertions.assertEquals(2, credsMap.size());
+    Assertions.assertThat(credsMap).hasSize(2);
     String sasToken = credsMap.get(PolarisCredentialProperty.AZURE_SAS_TOKEN);
-    Assertions.assertNotNull(sasToken);
+    Assertions.assertThat(sasToken).isNotNull();
     String serviceEndpoint =
         String.format("https://icebergdfsstorageacct.%s.core.windows.net", service);
     BlobContainerClient containerClient =
@@ -138,43 +138,44 @@ public class AzureCredentialStorageIntegrationTest {
 
     if (allowListAction) {
       // LIST succeed
-      Assertions.assertDoesNotThrow(
-          () -> {
-            if (isBlobService) {
-              containerClient
-                  .listBlobs(
-                      new ListBlobsOptions().setPrefix(Utility.urlEncode("polaris-test/")),
-                      Duration.ofSeconds(5))
-                  .streamByPage()
-                  .findFirst()
-                  .orElse(null);
-            } else {
-              fileSystemClient
-                  .getDirectoryClient("polaris-test")
-                  .listPaths()
-                  .forEach(PathItem::getName);
-            }
-          });
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () -> {
+                if (isBlobService) {
+                  containerClient
+                      .listBlobs(
+                          new ListBlobsOptions().setPrefix(Utility.urlEncode("polaris-test/")),
+                          Duration.ofSeconds(5))
+                      .streamByPage()
+                      .findFirst()
+                      .orElse(null);
+                } else {
+                  fileSystemClient
+                      .getDirectoryClient("polaris-test")
+                      .listPaths()
+                      .forEach(PathItem::getName);
+                }
+              });
     } else {
       if (isBlobService) {
-        Assertions.assertThrows(
-            BlobStorageException.class,
-            () ->
-                containerClient
-                    .listBlobs(
-                        new ListBlobsOptions().setPrefix(Utility.urlEncode("polaris-test/")),
-                        Duration.ofSeconds(5))
-                    .streamByPage()
-                    .findFirst()
-                    .orElse(null));
+        Assertions.assertThatThrownBy(
+                () ->
+                    containerClient
+                        .listBlobs(
+                            new ListBlobsOptions().setPrefix(Utility.urlEncode("polaris-test/")),
+                            Duration.ofSeconds(5))
+                        .streamByPage()
+                        .findFirst()
+                        .orElse(null))
+            .isInstanceOf(BlobStorageException.class);
       } else {
-        Assertions.assertThrows(
-            DataLakeStorageException.class,
-            () ->
-                fileSystemClient
-                    .getDirectoryClient("polaris-test")
-                    .listPaths()
-                    .forEach(PathItem::getName));
+        Assertions.assertThatThrownBy(
+                () ->
+                    fileSystemClient
+                        .getDirectoryClient("polaris-test")
+                        .listPaths()
+                        .forEach(PathItem::getName))
+            .isInstanceOf(DataLakeStorageException.class);
       }
     }
   }
@@ -205,20 +206,27 @@ public class AzureCredentialStorageIntegrationTest {
             allowedPrefix);
 
     // READ succeed
-    Assertions.assertDoesNotThrow(
-        () ->
-            blobClient.downloadStreamWithResponse(
-                new ByteArrayOutputStream(), null, null, null, false, Duration.ofSeconds(5), null));
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () ->
+                blobClient.downloadStreamWithResponse(
+                    new ByteArrayOutputStream(),
+                    null,
+                    null,
+                    null,
+                    false,
+                    Duration.ofSeconds(5),
+                    null));
 
     // read will fail because only READ permission allowed
-    Assertions.assertThrows(
-        BlobStorageException.class,
-        () ->
-            blobClient.uploadWithResponse(
-                new BlobParallelUploadOptions(
-                    new ByteArrayInputStream("polaris".getBytes(StandardCharsets.UTF_8))),
-                Duration.ofSeconds(5),
-                null));
+    Assertions.assertThatThrownBy(
+            () ->
+                blobClient.uploadWithResponse(
+                    new BlobParallelUploadOptions(
+                        new ByteArrayInputStream("polaris".getBytes(StandardCharsets.UTF_8))),
+                    Duration.ofSeconds(5),
+                    null))
+        .isInstanceOf(BlobStorageException.class);
 
     // read fail because container is blocked
     BlobClient blobClientReadFail =
@@ -228,11 +236,17 @@ public class AzureCredentialStorageIntegrationTest {
             "regtest",
             blockedPrefix);
 
-    Assertions.assertThrows(
-        BlobStorageException.class,
-        () ->
-            blobClientReadFail.downloadStreamWithResponse(
-                new ByteArrayOutputStream(), null, null, null, false, Duration.ofSeconds(5), null));
+    Assertions.assertThatThrownBy(
+            () ->
+                blobClientReadFail.downloadStreamWithResponse(
+                    new ByteArrayOutputStream(),
+                    null,
+                    null,
+                    null,
+                    false,
+                    Duration.ofSeconds(5),
+                    null))
+        .isInstanceOf(BlobStorageException.class);
   }
 
   @TestWithAzureArgs
@@ -271,25 +285,27 @@ public class AzureCredentialStorageIntegrationTest {
     // upload succeed
     ByteArrayInputStream inputStream =
         new ByteArrayInputStream("polaris".getBytes(StandardCharsets.UTF_8));
-    Assertions.assertDoesNotThrow(
-        () -> {
-          if (isBlobService) {
-            blobClient.uploadWithResponse(
-                new BlobParallelUploadOptions(inputStream), Duration.ofSeconds(5), null);
-          } else {
-            fileClient.upload(inputStream, "polaris".length(), /*override*/ true);
-          }
-        });
+    Assertions.assertThatNoException()
+        .isThrownBy(
+            () -> {
+              if (isBlobService) {
+                blobClient.uploadWithResponse(
+                    new BlobParallelUploadOptions(inputStream), Duration.ofSeconds(5), null);
+              } else {
+                fileClient.upload(inputStream, "polaris".length(), /*override*/ true);
+              }
+            });
     ByteArrayOutputStream outStream = new ByteArrayOutputStream();
     // READ not allowed
     if (isBlobService) {
-      Assertions.assertThrows(
-          BlobStorageException.class,
-          () ->
-              blobClient.downloadStreamWithResponse(
-                  outStream, null, null, null, false, Duration.ofSeconds(5), null));
+      Assertions.assertThatThrownBy(
+              () ->
+                  blobClient.downloadStreamWithResponse(
+                      outStream, null, null, null, false, Duration.ofSeconds(5), null))
+          .isInstanceOf(BlobStorageException.class);
     } else {
-      Assertions.assertThrows(DataLakeStorageException.class, () -> fileClient.read(outStream));
+      Assertions.assertThatThrownBy(() -> fileClient.read(outStream))
+          .isInstanceOf(DataLakeStorageException.class);
     }
 
     // upload fail because container not allowed
@@ -309,18 +325,17 @@ public class AzureCredentialStorageIntegrationTest {
             "00000-65ffa17b-fe64-4c38-bcb9-06f9bd12aa2a.metadata.json");
 
     if (isBlobService) {
-      Assertions.assertThrows(
-          BlobStorageException.class,
-          () ->
-              blobClientWriteFail.uploadWithResponse(
-                  new BlobParallelUploadOptions(
-                      new ByteArrayInputStream("polaris".getBytes(StandardCharsets.UTF_8))),
-                  Duration.ofSeconds(5),
-                  null));
+      Assertions.assertThatThrownBy(
+              () ->
+                  blobClientWriteFail.uploadWithResponse(
+                      new BlobParallelUploadOptions(
+                          new ByteArrayInputStream("polaris".getBytes(StandardCharsets.UTF_8))),
+                      Duration.ofSeconds(5),
+                      null))
+          .isInstanceOf(BlobStorageException.class);
     } else {
-      Assertions.assertThrows(
-          DataLakeStorageException.class,
-          () -> fileClientFail.upload(inputStream, "polaris".length()));
+      Assertions.assertThatThrownBy(() -> fileClientFail.upload(inputStream, "polaris".length()))
+          .isInstanceOf(DataLakeStorageException.class);
     }
   }
 

--- a/polaris-core/src/test/java/io/polaris/service/storage/azure/AzureLocationTest.java
+++ b/polaris-core/src/test/java/io/polaris/service/storage/azure/AzureLocationTest.java
@@ -16,7 +16,7 @@
 package io.polaris.service.storage.azure;
 
 import io.polaris.core.storage.azure.AzureLocation;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AzureLocationTest {
@@ -25,22 +25,23 @@ public class AzureLocationTest {
   public void testLocation() {
     String uri = "abfss://container@storageaccount.blob.core.windows.net/myfile";
     AzureLocation azureLocation = new AzureLocation(uri);
-    Assertions.assertEquals("container", azureLocation.getContainer());
-    Assertions.assertEquals("storageaccount", azureLocation.getStorageAccount());
-    Assertions.assertEquals("blob.core.windows.net", azureLocation.getEndpoint());
-    Assertions.assertEquals("myfile", azureLocation.getFilePath());
+    Assertions.assertThat(azureLocation.getContainer()).isEqualTo("container");
+    Assertions.assertThat(azureLocation.getStorageAccount()).isEqualTo("storageaccount");
+    Assertions.assertThat(azureLocation.getEndpoint()).isEqualTo("blob.core.windows.net");
+    Assertions.assertThat(azureLocation.getFilePath()).isEqualTo("myfile");
   }
 
   @Test
   public void testLocation_negative_cases() {
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> new AzureLocation("wasbs://container@storageaccount.blob.core.windows.net/myfile"));
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> new AzureLocation("abfss://storageaccount.blob.core.windows.net/myfile"));
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> new AzureLocation("abfss://container@storageaccount/myfile"));
+    Assertions.assertThatThrownBy(
+            () ->
+                new AzureLocation("wasbs://container@storageaccount.blob.core.windows.net/myfile"))
+        .isInstanceOf(IllegalArgumentException.class);
+    Assertions.assertThatThrownBy(
+            () -> new AzureLocation("abfss://storageaccount.blob.core.windows.net/myfile"))
+        .isInstanceOf(IllegalArgumentException.class);
+    Assertions.assertThatThrownBy(
+            () -> new AzureLocation("abfss://container@storageaccount/myfile"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/polaris-core/src/test/java/io/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/io/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -48,9 +48,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.assertj.core.util.Strings;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -90,30 +90,33 @@ class GcpCredentialsStorageIntegrationTest {
         createStorageBlob("sfc-dev1-regtest", "polaris-test/subscoped-test/read1/", "file.txt");
     final byte[] fileContent = "hello-polaris".getBytes();
     // GOOD WRITE
-    Assertions.assertDoesNotThrow(() -> storageClient.create(blobInfoGoodWrite, fileContent));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> storageClient.create(blobInfoGoodWrite, fileContent));
 
     // BAD WROTE
-    Assertions.assertThrows(
-        StorageException.class, () -> storageClient.create(blobInfoBad, fileContent));
+    Assertions.assertThatThrownBy(() -> storageClient.create(blobInfoBad, fileContent))
+        .isInstanceOf(StorageException.class);
 
-    Assertions.assertDoesNotThrow(() -> storageClient.get(blobInfoGoodRead.getBlobId()));
-    Assertions.assertThrows(
-        StorageException.class, () -> storageClient.get(blobInfoBad.getBlobId()));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> storageClient.get(blobInfoGoodRead.getBlobId()));
+    Assertions.assertThatThrownBy(() -> storageClient.get(blobInfoBad.getBlobId()))
+        .isInstanceOf(StorageException.class);
 
     // LIST
     if (allowedListAction) {
-      Assertions.assertDoesNotThrow(
-          () ->
-              storageClient.list(
-                  "sfc-dev1-regtest",
-                  Storage.BlobListOption.prefix("polaris-test/subscoped-test/read1/")));
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  storageClient.list(
+                      "sfc-dev1-regtest",
+                      Storage.BlobListOption.prefix("polaris-test/subscoped-test/read1/")));
     } else {
-      Assertions.assertThrows(
-          StorageException.class,
-          () ->
-              storageClient.list(
-                  "sfc-dev1-regtest",
-                  Storage.BlobListOption.prefix("polaris-test/subscoped-test/read1/")));
+      Assertions.assertThatThrownBy(
+              () ->
+                  storageClient.list(
+                      "sfc-dev1-regtest",
+                      Storage.BlobListOption.prefix("polaris-test/subscoped-test/read1/")))
+          .isInstanceOf(StorageException.class);
     }
     // DELETE
     List<String> allowedWrite2 =
@@ -123,11 +126,12 @@ class GcpCredentialsStorageIntegrationTest {
     Storage clientForDelete = setupStorageClient(List.of(), allowedWrite2, allowedListAction);
 
     // can not delete because it is not in allowed write path for this client
-    Assertions.assertThrows(
-        StorageException.class, () -> clientForDelete.delete(blobInfoGoodWrite.getBlobId()));
+    Assertions.assertThatThrownBy(() -> clientForDelete.delete(blobInfoGoodWrite.getBlobId()))
+        .isInstanceOf(StorageException.class);
 
     // good to delete allowed location
-    Assertions.assertDoesNotThrow(() -> storageClient.delete(blobInfoGoodWrite.getBlobId()));
+    Assertions.assertThatNoException()
+        .isThrownBy(() -> storageClient.delete(blobInfoGoodWrite.getBlobId()));
   }
 
   private Storage setupStorageClient(


### PR DESCRIPTION
# Description

PolarisObjectMapperUtilTest already uses AssertJ. 
AssertJ provides more helpful messages than JUnit when failed. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [x] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
