### PR TITLE
Add README note about default (in-memory) credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Run the Polaris server locally on localhost:8181
 ./gradlew runApp
 ```
 
+The server will start using the in-memory mode, and it will print its auto-generated credentials to STDOUT in a message like the following:
+
+```text
+realm: default-realm root principal credentials: <id>:<secret>
+```
+
+These credentials can be used as "Client ID" and "Client Secret" in OAuth2 requests (e.g. the `curl` command below).
+
 While the Polaris server is running, run regression tests, or end-to-end tests in another terminal
 
 ```


### PR DESCRIPTION
# Description

Add README note about default (in-memory) credentials
    
This is to help users to get started with source builds.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual execution of the related README instructions.
# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
