### PR TITLE
README: add `docker.io/` qualifier for podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Docs are generated using [Redocly](https://redocly.com/docs/cli/installation). T
 from the project root directory
 
 ```bash
-docker run -p 8080:80 -v ${PWD}:/spec redocly/cli join spec/docs.yaml spec/polaris-management-service.yml spec/rest-catalog-open-api.yaml -o spec/index.yaml --prefix-components-with-info-prop title
-docker run -p 8080:80 -v ${PWD}:/spec redocly/cli build-docs spec/index.yaml --output=docs/index.html --config=spec/redocly.yaml
+docker run -p 8080:80 -v ${PWD}:/spec docker.io/redocly/cli join spec/docs.yaml spec/polaris-management-service.yml spec/rest-catalog-open-api.yaml -o spec/index.yaml --prefix-components-with-info-prop title
+docker run -p 8080:80 -v ${PWD}:/spec docker.io/redocly/cli build-docs spec/index.yaml --output=docs/index.html --config=spec/redocly.yaml
 ```
 
 # Setup


### PR DESCRIPTION
In case you have (configured) multiple "default" Docker repositories, as it's the case for most podman setups, you have to choose the "right" one here. This change prevents this manual intervention.
