### PR TITLE
Docker compose: remove host network requirement when building

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
   polaris:
     build:
       context: .
-      network: host
     ports:
       - "8181:8181"
       - "8182"
@@ -47,7 +46,6 @@ services:
   regtest:
     build:
       context: regtests
-      network: host
       args:
         POLARIS_HOST: polaris
     depends_on:


### PR DESCRIPTION
# Description

This PR fixes the following issue when running docker-compose:

    failed to solve: granting entitlement network.host is not allowed by build daemon configuration

Using the host network is not required anyway, as the build is able to finish without it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually by running:

```shell
docker compose -f docker-compose.yml up --build
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
