### PR TITLE
Support user-specified paths for conf-file in the eclipse-link metastore manager

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/io/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/io/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -47,7 +47,6 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.Persistence;
-
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;

--- a/extension/persistence/eclipselink/src/main/java/io/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/io/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -47,6 +47,9 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.Persistence;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -117,6 +120,15 @@ public class PolarisEclipseLinkMetaStoreSessionImpl implements PolarisMetaStoreS
     this.storageIntegrationProvider = storageIntegrationProvider;
   }
 
+  private InputStream loadFile(String path) throws FileNotFoundException {
+    InputStream input = null;
+    input = this.getClass().getClassLoader().getResourceAsStream(path);
+    if (input == null) {
+      input = new FileInputStream(path);
+    }
+    return input;
+  }
+
   /** Load the persistence unit properties from a given configuration file */
   private Map<String, String> loadProperties(String confFile, String persistenceUnitName) {
     if (this.properties != null) {
@@ -124,7 +136,7 @@ public class PolarisEclipseLinkMetaStoreSessionImpl implements PolarisMetaStoreS
     }
 
     try {
-      InputStream input = this.getClass().getClassLoader().getResourceAsStream(confFile);
+      InputStream input = loadFile(confFile);
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       DocumentBuilder builder = factory.newDocumentBuilder();
       Document doc = builder.parse(input);


### PR DESCRIPTION
# Description

Previously only resources bundled in the JAR could be used as the EclipseLink configuration file. This change adds support for arbitrary locations specified as the `conf-file` without breaking support for files included in the JAR.

It will first check for a file included in the JAR matching the path, and it will fall back to trying to load the file directly if that fails.

Fixes #45

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Confirmed I'm able to load a persistence.xml file at a new location with the change, where previously it gave:
```
Cannot find or parse the configuration file...
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
