### PR TITLE
Don't re-use STS Client Builder across threads

### DIFF
--- a/polaris-service/src/main/java/io/polaris/service/PolarisApplication.java
+++ b/polaris-service/src/main/java/io/polaris/service/PolarisApplication.java
@@ -144,13 +144,16 @@ public class PolarisApplication extends Application<PolarisApplicationConfig> {
     // PolarisEntityManager will be used for Management APIs and optionally the core Catalog APIs
     // depending on the value of the baseCatalogType config.
     MetaStoreManagerFactory metaStoreManagerFactory = configuration.getMetaStoreManagerFactory();
-    StsClientBuilder stsClientBuilder = StsClient.builder();
-    AwsCredentialsProvider awsCredentialsProvider = configuration.credentialsProvider();
-    if (awsCredentialsProvider != null) {
-      stsClientBuilder.credentialsProvider(awsCredentialsProvider);
-    }
+
     metaStoreManagerFactory.setStorageIntegrationProvider(
-        new PolarisStorageIntegrationProviderImpl(stsClientBuilder::build));
+        new PolarisStorageIntegrationProviderImpl(() -> {
+          StsClientBuilder stsClientBuilder = StsClient.builder();
+          AwsCredentialsProvider awsCredentialsProvider = configuration.credentialsProvider();
+          if (awsCredentialsProvider != null) {
+            stsClientBuilder.credentialsProvider(awsCredentialsProvider);
+          }
+          return stsClientBuilder.build();
+        }));
 
     PolarisMetricRegistry polarisMetricRegistry =
         new PolarisMetricRegistry(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT));

--- a/polaris-service/src/main/java/io/polaris/service/PolarisApplication.java
+++ b/polaris-service/src/main/java/io/polaris/service/PolarisApplication.java
@@ -146,14 +146,15 @@ public class PolarisApplication extends Application<PolarisApplicationConfig> {
     MetaStoreManagerFactory metaStoreManagerFactory = configuration.getMetaStoreManagerFactory();
 
     metaStoreManagerFactory.setStorageIntegrationProvider(
-        new PolarisStorageIntegrationProviderImpl(() -> {
-          StsClientBuilder stsClientBuilder = StsClient.builder();
-          AwsCredentialsProvider awsCredentialsProvider = configuration.credentialsProvider();
-          if (awsCredentialsProvider != null) {
-            stsClientBuilder.credentialsProvider(awsCredentialsProvider);
-          }
-          return stsClientBuilder.build();
-        }));
+        new PolarisStorageIntegrationProviderImpl(
+            () -> {
+              StsClientBuilder stsClientBuilder = StsClient.builder();
+              AwsCredentialsProvider awsCredentialsProvider = configuration.credentialsProvider();
+              if (awsCredentialsProvider != null) {
+                stsClientBuilder.credentialsProvider(awsCredentialsProvider);
+              }
+              return stsClientBuilder.build();
+            }));
 
     PolarisMetricRegistry polarisMetricRegistry =
         new PolarisMetricRegistry(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT));


### PR DESCRIPTION
# Description

Per the [docs](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/client/builder/SdkClientBuilder.html), this `...Builder` class is probably not thread safe:

> Implementations of this interface are mutable and not thread-safe.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Without this fix:
```
ARN  [2024-08-02 20:16:37,178 - 3816146] [pool-3-thread-24 - POST /api/catalog/v1/zfab-test-1/namespaces/abc/tables] [] org.apache.iceberg.util.Tasks: Retrying task after failure: Encountered a null value when resolving configuration attributes. This is commonly caused by concurrent modifications to non-thread-safe types. Ensure you're synchronizing access to all non-thread-safe types. 
java.lang.NullPointerException: Encountered a null value when resolving configuration attributes. This is commonly caused by concurrent modifications to non-thread-safe types. Ensure you're synchronizing access to all non-thread-safe types.
        at software.amazon.awssdk.utils.Validate.notNull(Validate.java:119)
        at software.amazon.awssdk.utils.AttributeMap$Builder.resolveValue(AttributeMap.java:396)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at software.amazon.awssdk.utils.AttributeMap$Builder.build(AttributeMap.java:362)
        at software.amazon.awssdk.core.client.config.SdkClientConfiguration$Builder.build(SdkClientConfiguration.java:232)
        at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.syncClientConfiguration(SdkDefaultClientBuilder.java:187)
        at software.amazon.awssdk.services.sts.DefaultStsClientBuilder.buildClient(DefaultStsClientBuilder.java:36)
        at software.amazon.awssdk.services.sts.DefaultStsClientBuilder.buildClient(DefaultStsClientBuilder.java:25)
        at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.build(SdkDefaultClientBuilder.java:164)
        at io.polaris.service.storage.PolarisStorageIntegrationProviderImpl.getStorageIntegrationForConfig(PolarisStorageIntegrationProviderImpl.java:61)
        at io.polaris.extension.persistence.impl.eclipselink.PolarisEclipseLinkMetaStoreSessionImpl.loadPolarisStorageIntegration(PolarisEclipseLinkMetaStoreSessionImpl.java:683)
. . .
```

I cannot repro the above after this fix.
