### PR TITLE
Dockerfile: use non-`docker.io` registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,21 @@
 # limitations under the License.
 #
 # Base Image
-FROM gradle:8.6-jdk21 as build
+# Use a non-docker-io registry, because pulling images from docker.io is
+# subject to aggressive request rate limiting and bandwidth shaping.
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime as build
 
 # Copy the REST catalog into the container
-COPY . /app
+COPY --chown=default:root . /app
 
 # Set the working directory in the container, nuke any existing builds
 WORKDIR /app
 RUN rm -rf build
 
 # Build the rest catalog
-RUN gradle --no-daemon --info shadowJar
+RUN ./gradlew --no-daemon --info clean shadowJar
 
-FROM openjdk:21
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 WORKDIR /app
 COPY --from=build /app/polaris-service/build/libs/polaris-service-1.0.0-all.jar /app
 COPY --from=build /app/polaris-server.yml /app

--- a/regtests/Dockerfile
+++ b/regtests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/spark:3.5.1-python3
+FROM docker.io/apache/spark:3.5.1-python3
 ARG POLARIS_HOST=polaris
 ENV POLARIS_HOST=$POLARIS_HOST
 ENV SPARK_HOME=/opt/spark


### PR DESCRIPTION
Update the `Dockerfile` to use the ubi9 openjdk 21 runtime image for both the build and final image.

Pulling from `docker.io` is subject to aggressive request rate limiting and bandwidth shaping.
