### PR TITLE
Fix cli where env variables are not getting used

### DIFF
--- a/regtests/client/python/cli/polaris_cli.py
+++ b/regtests/client/python/cli/polaris_cli.py
@@ -91,7 +91,7 @@ class PolarisCli:
         client_id = options.client_id or os.getenv(CLIENT_ID_ENV)
         client_secret = options.client_secret or os.getenv(CLIENT_SECRET_ENV)
         
-        # Validate
+        # Validates
         has_access_token = options.access_token is not None
         has_client_secret = client_id is not None and client_secret is not None
         if has_access_token and has_client_secret:

--- a/regtests/client/python/cli/polaris_cli.py
+++ b/regtests/client/python/cli/polaris_cli.py
@@ -111,14 +111,6 @@ class PolarisCli:
             builder = lambda: ApiClient(
                 Configuration(host=polaris_management_url, username=client_id, password=client_secret),
             )
-        elif os.getenv(CLIENT_ID_ENV) and os.getenv(CLIENT_SECRET_ENV):
-            builder = lambda: ApiClient(
-                Configuration(
-                    host=polaris_management_url,
-                    username=os.getenv(CLIENT_ID_ENV),
-                    password=os.getenv(CLIENT_SECRET_ENV)
-                )
-            )
         else:
             raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
                             f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'

--- a/regtests/client/python/cli/polaris_cli.py
+++ b/regtests/client/python/cli/polaris_cli.py
@@ -87,10 +87,13 @@ class PolarisCli:
 
     @staticmethod
     def _get_client_builder(options):
-
+        # Determine which credentials to use
+        client_id = options.client_id or os.getenv(CLIENT_ID_ENV)
+        client_secret = options.client_secret or os.getenv(CLIENT_SECRET_ENV)
+        
         # Validate
         has_access_token = options.access_token is not None
-        has_client_secret = options.client_id is not None and options.client_secret is not None
+        has_client_secret = client_id is not None and client_secret is not None
         if has_access_token and has_client_secret:
             raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
                             f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'
@@ -106,9 +109,9 @@ class PolarisCli:
             )
         elif has_client_secret:
             builder = lambda: ApiClient(
-                Configuration(host=polaris_management_url, username=options.client_id, password=options.client_secret),
+                Configuration(host=polaris_management_url, username=client_id, password=client_secret),
             )
-        elif os.getenv('CLIENT_ID') and os.getenv('CLIENT_SECRET'):
+        elif os.getenv(CLIENT_ID_ENV) and os.getenv(CLIENT_SECRET_ENV):
             builder = lambda: ApiClient(
                 Configuration(
                     host=polaris_management_url,
@@ -124,12 +127,11 @@ class PolarisCli:
                             f' {CLIENT_SECRET_ENV}.')
 
         if not has_access_token and not PolarisCli.DIRECT_AUTHENTICATION_ENABLED:
-            token = PolarisCli._get_token(builder(), polaris_catalog_url, options.client_id, options.client_secret)
+            token = PolarisCli._get_token(builder(), polaris_catalog_url, client_id, client_secret)
             builder = lambda: ApiClient(
                 Configuration(host=polaris_management_url, access_token=token),
             )
         return builder
-
 
 
 if __name__ == '__main__':

--- a/regtests/client/python/cli/polaris_cli.py
+++ b/regtests/client/python/cli/polaris_cli.py
@@ -98,7 +98,12 @@ class PolarisCli:
             raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
                             f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'
                             f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}, but not both')
-
+        if not has_access_token and not has_client_secret:
+            raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
+                            f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'
+                            f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}.'
+                            f' Alternatively, you may set the environment variables {CLIENT_ID_ENV} &'
+                            f' {CLIENT_SECRET_ENV}.')
         # Authenticate accordingly
         polaris_management_url = f'http://{options.host}:{options.port}/api/management/v1'
         polaris_catalog_url = f'http://{options.host}:{options.port}/api/catalog/v1'
@@ -111,12 +116,6 @@ class PolarisCli:
             builder = lambda: ApiClient(
                 Configuration(host=polaris_management_url, username=client_id, password=client_secret),
             )
-        else:
-            raise Exception(f'Please provide credentials via either {Argument.to_flag_name(Arguments.CLIENT_ID)} &'
-                            f' {Argument.to_flag_name(Arguments.CLIENT_SECRET)} or'
-                            f' {Argument.to_flag_name(Arguments.ACCESS_TOKEN)}.'
-                            f' Alternatively, you may set the environment variables {CLIENT_ID_ENV} &'
-                            f' {CLIENT_SECRET_ENV}.')
 
         if not has_access_token and not PolarisCli.DIRECT_AUTHENTICATION_ENABLED:
             token = PolarisCli._get_token(builder(), polaris_catalog_url, client_id, client_secret)


### PR DESCRIPTION
# Description

When an end-user use env variables for `client-id` and `client-secret` for polaris cli, the value of  `client-id` and `client-secret` are not being used:

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verify `client-id` and `client-secret` are indeed being used:
```
./polaris --client-id xxxxx --client-secret xxxxx catalogs list
```

Then tried the same with env variables route:
```
export CLIENT_ID=xxxxx
export CLIENT_SECRET=xxxxx
./polaris catalogs list
```

Without the purposed code change, the catalogs list operation will failed due to the following line of code as it will try to load the `client-id` and `client-secret` from command line arguments regardless (https://github.com/MonkeyCanCode/polaris/blob/main/regtests/client/python/cli/polaris_cli.py):
```
token = PolarisCli._get_token(builder(), polaris_catalog_url, options.client_id, options.client_secret)
```
Thus generating following error:
```
Traceback (most recent call last):
  File "regtests/client/python/cli/polaris_cli.py", line 136, in <module>
    PolarisCli.execute()
  File "regtests/client/python/cli/polaris_cli.py", line 47, in execute
    client_builder = PolarisCli._get_client_builder(options)
  File "regtests/client/python/cli/polaris_cli.py", line 127, in _get_client_builder
    token = PolarisCli._get_token(builder(), polaris_catalog_url, options.client_id, options.client_secret)
  File "regtests/client/python/cli/polaris_cli.py", line 85, in _get_token
    raise Exception('Failed to get access token')
Exception: Failed to get access token
```

With the purposed fixed, it will then read from env variables and produce output similar to following:
```
{"type": "INTERNAL", "name": "my_catalog", "properties": {"default-base-location": "file:///tmp/1"}, "createTimestamp": 1722802273684, "lastUpdateTimestamp": 1722802273684, "entityVersion": 1, "storageConfigInfo": {"storageType": "FILE", "allowedLocations": ["file:///tmp/1"]}}
```

# Checklist:

Please delete options that are not relevant.

- [x ] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [x ] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
