### PR TITLE
CI: `setup-gradle` action, no `validate-wrappers`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,6 +48,10 @@ jobs:
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4
+        with:
+          # The setup-gradle action fails, if the wrapper is not using the right version or is not present.
+          # Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
+          validate-wrappers: false
 
       - name: Check formatting
         run: ./gradlew check


### PR DESCRIPTION
The setup-gradle action fails, if the wrapper is not using the right version, is not present. Our `gradlew` validates the integrity of the `gradle-wrapper.jar`, so it's safe to disable this.
