### PR TITLE
Add mini k8s deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Running in Docker
 
 Running in Kubernetes
 - `./setup.sh` - To run Polaris as a mini-deployment locally. This will create two pods that bind themselves to port `8181`.
+- `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster.
 - `kubectl get pods -n polaris` - To check the status of the pods.
 - `kubectl get deployment -n polaris` - To check the status of the deployment.
 - `kubectl describe deployment polaris-deployment -n polaris` - To troubleshoot if things aren't working as expected.
-- `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster.
 
 Building docs
 - Docs are generated using [Redocly](https://redocly.com/docs/cli/installation). To regenerate them, run the following

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Running in Docker
 
 Running in Kubernetes
 - `./setup.sh` - To run Polaris as a mini-deployment locally. This will create two pods that bind themselves to port `8181`.
-- `kubectl get pods` - To check the status of the pods.
-- `kubectl get deployment` - To check the status of the deployment.
-- `kubectl describe deployment polaris-deployment` - To troubleshoot if things aren't working as expected.
+- `kubectl get pods -n polaris` - To check the status of the pods.
+- `kubectl get deployment -n polaris` - To check the status of the deployment.
+- `kubectl describe deployment polaris-deployment -n polaris` - To troubleshoot if things aren't working as expected.
+- `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster.
 
 Building docs
 - Docs are generated using [Redocly](https://redocly.com/docs/cli/installation). To regenerate them, run the following

--- a/k8/deployment.yaml
+++ b/k8/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name:  polaris
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: polaris
+  namespace: polaris
+spec:
+  selector:
+    matchLabels:
+      app: polaris
+  template:
+    metadata:
+      labels:
+        app: polaris
+    spec:
+      containers:
+      - name: polaris
+        image: localhost:5001/polaris:latest
+        ports:
+        - containerPort: 8181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: polaris
+  namespace: polaris
+spec:
+  selector:
+    app: polaris
+  ports:
+  - port: 8181
+    targetPort: 8181

--- a/k8/deployment.yaml
+++ b/k8/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   name: polaris-deployment
   namespace: polaris
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: polaris

--- a/k8/deployment.yaml
+++ b/k8/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: polaris
+  name: polaris-deployment
   namespace: polaris
 spec:
   selector:
@@ -26,7 +26,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: polaris
+  name: polaris-service
   namespace: polaris
 spec:
   selector:


### PR DESCRIPTION
# Description

Add a mini k8s deployment for running polaris.

Fixes # [[DOC] Directions to run mini-deployment reference k8 directory that does not exist
](https://github.com/polaris-catalog/polaris/issues/99)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Here are all of the resources that got deployed with this deployment:
```
kubectl get all -n polaris
NAME                                      READY   STATUS    RESTARTS   AGE
pod/polaris-deployment-5b8457d65d-dhp5r   1/1     Running   0          108s

NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/polaris-service   ClusterIP   10.96.173.228   <none>        8181/TCP   108s

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/polaris-deployment   1/1     1            1           108s

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/polaris-deployment-5b8457d65d   1         1         1       108s
```

On one session, performs a port forwarding for the svc:
```
kubectl port-forward svc/polaris-service -n polaris 8181:8181
Forwarding from 127.0.0.1:8181 -> 8181
Forwarding from [::1]:8181 -> 8181
```

On a new session, get the auth token from pod (in-memory deployment) then use polaris cli to perform auth:
```
kubectl  logs pods/polaris-deployment-5b8457d65d-dhp5r -n polaris | grep 'realm: default-realm root principal credentials:'
realm: default-realm root principal credentials: 2d54798a730ef589:b5b6ac216c5441e7421f241673837751
...
./polaris --client-id 2d54798a730ef589 --client-secret b5b6ac216c5441e7421f241673837751 principals list
{"name": "root", "clientId": "2d54798a730ef589", "properties": {}, "createTimestamp": 1723000008560, "lastUpdateTimestamp": 1723000008560, "entityVersion": 1}
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [x] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
