### PR TITLE
Server code on Java 21, client code on Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # Base Image
 # Use a non-docker-io registry, because pulling images from docker.io is
 # subject to aggressive request rate limiting and bandwidth shaping.
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime as build
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936 as build
 
 # Copy the REST catalog into the container
 COPY --chown=default:root . /app
@@ -28,7 +28,7 @@ RUN rm -rf build
 # Build the rest catalog
 RUN ./gradlew --no-daemon --info clean shadowJar
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.20-2.1721752928
 WORKDIR /app
 COPY --from=build /app/polaris-service/build/libs/polaris-service-1.0.0-all.jar /app
 COPY --from=build /app/polaris-server.yml /app

--- a/build-logic/src/main/kotlin/polaris-client.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-client.gradle.kts
@@ -18,4 +18,4 @@ import org.gradle.api.tasks.compile.JavaCompile
 
 plugins { id("polaris-java") }
 
-tasks.withType(JavaCompile::class.java).configureEach { options.release = 21 }
+tasks.withType(JavaCompile::class.java).configureEach { options.release = 11 }

--- a/build-logic/src/main/kotlin/polaris-java.gradle.kts
+++ b/build-logic/src/main/kotlin/polaris-java.gradle.kts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 Snowflake Computing Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.named
+
+plugins {
+  id("jacoco")
+  id("java")
+  id("com.diffplug.spotless")
+  id("jacoco-report-aggregation")
+  id("net.ltgt.errorprone")
+}
+
+tasks.withType(JavaCompile::class.java).configureEach {
+  options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Xlint:deprecation"))
+  options.errorprone.disableAllWarnings = true
+  options.errorprone.disableWarningsInGeneratedCode = true
+  options.errorprone.error("StringCaseLocaleUsage")
+}
+
+tasks.register("format").configure { dependsOn("spotlessApply") }
+
+tasks.named<Test>("test").configure {
+  useJUnitPlatform()
+  jvmArgs("-Duser.language=en")
+}
+
+spotless {
+  val disallowWildcardImports = { text: String ->
+    val regex = "~/import .*\\.\\*;/".toRegex()
+    if (regex.matches(text)) {
+      throw GradleException("Wildcard imports disallowed - ${regex.findAll(text)}")
+    }
+    text
+  }
+  java {
+    target("src/main/java/**/*.java", "src/testFixtures/java/**/*.java", "src/test/java/**/*.java")
+    googleJavaFormat()
+    licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"))
+    endWithNewline()
+    custom("disallowWildcardImports", disallowWildcardImports)
+  }
+  kotlinGradle {
+    ktfmt().googleStyle()
+    licenseHeaderFile(rootProject.file("codestyle/copyright-header-java.txt"), "$")
+    target("*.gradle.kts")
+  }
+  format("xml") {
+    target("src/**/*.xml", "src/**/*.xsd")
+    targetExclude("codestyle/copyright-header.xml")
+    eclipseWtp(com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep.XML)
+      .configFile(rootProject.file("codestyle/org.eclipse.wst.xml.core.prefs"))
+    // getting the license-header delimiter right is a bit tricky.
+    // licenseHeaderFile(rootProject.file("codestyle/copyright-header.xml"), '<^[!?].*$')
+  }
+}
+
+dependencies { errorprone(versionCatalogs.named("libs").findLibrary("errorprone").get()) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ sqllite-jdbc = { module = "org.xerial:sqlite-jdbc", version = "3.45.1.0" }
 swagger-annotations = { module = "io.swagger:swagger-annotations", version.ref = "swagger" }
 swagger-jaxrs = { module = "io.swagger:swagger-jaxrs", version.ref = "swagger" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "1.20.0" }
+threeten-extra = { module = "org.threeten:threeten-extra", version = "1.8.0" }
 
 [plugins]
 openapi-generator = { id = "org.openapi.generator", version = "7.6.0" }

--- a/polaris-core/build.gradle.kts
+++ b/polaris-core/build.gradle.kts
@@ -18,7 +18,7 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
   alias(libs.plugins.openapi.generator)
-  id("polaris-server")
+  id("polaris-client")
   id("java-library")
   id("java-test-fixtures")
 }
@@ -113,6 +113,7 @@ dependencies {
   testFixturesApi("com.fasterxml.jackson.core:jackson-core")
   testFixturesApi("com.fasterxml.jackson.core:jackson-databind")
   testFixturesApi(libs.commons.lang3)
+  testFixturesApi(libs.threeten.extra)
   testFixturesApi(libs.jetbrains.annotations)
   testFixturesApi(platform(libs.jackson.bom))
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/polaris-core/src/main/java/io/polaris/core/persistence/PolarisResolvedPathWrapper.java
+++ b/polaris-core/src/main/java/io/polaris/core/persistence/PolarisResolvedPathWrapper.java
@@ -17,6 +17,7 @@ package io.polaris.core.persistence;
 
 import io.polaris.core.entity.PolarisEntity;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Holds fully-resolved path of PolarisEntities representing the targetEntity with all its grants
@@ -54,7 +55,7 @@ public class PolarisResolvedPathWrapper {
     if (resolvedPath == null) {
       return null;
     }
-    return resolvedPath.stream().map(ResolvedPolarisEntity::getEntity).toList();
+    return resolvedPath.stream().map(ResolvedPolarisEntity::getEntity).collect(Collectors.toList());
   }
 
   public List<ResolvedPolarisEntity> getResolvedParentPath() {
@@ -68,7 +69,9 @@ public class PolarisResolvedPathWrapper {
     if (resolvedPath == null) {
       return null;
     }
-    return getResolvedParentPath().stream().map(ResolvedPolarisEntity::getEntity).toList();
+    return getResolvedParentPath().stream()
+        .map(ResolvedPolarisEntity::getEntity)
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/polaris-core/src/main/java/io/polaris/core/persistence/cache/EntityCacheEntry.java
+++ b/polaris-core/src/main/java/io/polaris/core/persistence/cache/EntityCacheEntry.java
@@ -20,6 +20,7 @@ import io.polaris.core.PolarisDiagnostics;
 import io.polaris.core.entity.PolarisBaseEntity;
 import io.polaris.core.entity.PolarisGrantRecord;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 
 /** An entry in our entity cache. Note, this is fully immutable */
@@ -108,13 +109,15 @@ public class EntityCacheEntry {
   }
 
   public @NotNull List<PolarisGrantRecord> getGrantRecordsAsGrantee() {
-    return grantRecords.stream().filter(record -> record.getGranteeId() == entity.getId()).toList();
+    return grantRecords.stream()
+        .filter(record -> record.getGranteeId() == entity.getId())
+        .collect(Collectors.toList());
   }
 
   public @NotNull List<PolarisGrantRecord> getGrantRecordsAsSecurable() {
     return grantRecords.stream()
         .filter(record -> record.getSecurableId() == entity.getId())
-        .toList();
+        .collect(Collectors.toList());
   }
 
   public void updateLastAccess() {

--- a/polaris-core/src/main/java/io/polaris/core/persistence/resolver/PolarisResolutionManifest.java
+++ b/polaris-core/src/main/java/io/polaris/core/persistence/resolver/PolarisResolutionManifest.java
@@ -206,7 +206,7 @@ public class PolarisResolutionManifest implements PolarisResolutionManifestCatal
             "Returning null for key {} due to size mismatch from getPassthroughResolvedPath "
                 + "resolvedPath: {}, requestedPath.getEntityNames(): {}",
             key,
-            resolvedPath.stream().map(ResolvedPolarisEntity::new).toList(),
+            resolvedPath.stream().map(ResolvedPolarisEntity::new).collect(Collectors.toList()),
             requestedPath.getEntityNames());
         return null;
       }

--- a/polaris-core/src/main/java/io/polaris/core/persistence/resolver/Resolver.java
+++ b/polaris-core/src/main/java/io/polaris/core/persistence/resolver/Resolver.java
@@ -333,7 +333,7 @@ public class Resolver {
         "resolver_must_be_successful");
     this.diagnostics.check(this.resolvedPaths.size() == 1, "only_if_single");
 
-    return resolvedPaths.getFirst();
+    return resolvedPaths.get(0);
   }
 
   /**

--- a/polaris-core/src/test/java/io/polaris/core/persistence/EntityCacheTest.java
+++ b/polaris-core/src/test/java/io/polaris/core/persistence/EntityCacheTest.java
@@ -28,6 +28,7 @@ import io.polaris.core.persistence.cache.EntityCacheByNameKey;
 import io.polaris.core.persistence.cache.EntityCacheEntry;
 import io.polaris.core.persistence.cache.EntityCacheLookupResult;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -213,9 +214,9 @@ public class EntityCacheTest {
             .filter(
                 grantRecord ->
                     grantRecord.getPrivilegeCode() == PolarisPrivilege.TABLE_READ_DATA.getCode())
-            .toList();
+            .collect(Collectors.toList());
     Assertions.assertThat(matchPriv).hasSize(1);
-    gr = matchPriv.getFirst();
+    gr = matchPriv.get(0);
     Assertions.assertThat(gr.getGranteeId()).isEqualTo(cacheEntry_R1.getEntity().getId());
     Assertions.assertThat(gr.getGranteeCatalogId())
         .isEqualTo(cacheEntry_R1.getEntity().getCatalogId());

--- a/polaris-core/src/test/java/io/polaris/core/persistence/ResolverTest.java
+++ b/polaris-core/src/test/java/io/polaris/core/persistence/ResolverTest.java
@@ -283,7 +283,7 @@ public class ResolverTest {
 
     // now grant R3 to PR2
     Assertions.assertThat(resolver.getResolvedCallerPrincipalRoles()).hasSize(1);
-    PolarisBaseEntity PR2 = resolver.getResolvedCallerPrincipalRoles().getFirst().getEntity();
+    PolarisBaseEntity PR2 = resolver.getResolvedCallerPrincipalRoles().get(0).getEntity();
     this.tm.grantToGrantee(TEST, R3, PR2, PolarisPrivilege.CATALOG_ROLE_USAGE);
 
     // now resolve again with only PR2 activated, should see the new catalog role R3
@@ -321,7 +321,7 @@ public class ResolverTest {
     // get the various entities in the path
     Assertions.assertThat(resolver.getResolvedPath()).isNotNull();
     Assertions.assertThat(resolver.getResolvedPath()).hasSize(3);
-    PolarisBaseEntity N1 = resolver.getResolvedPath().getFirst().getEntity();
+    PolarisBaseEntity N1 = resolver.getResolvedPath().get(0).getEntity();
     PolarisBaseEntity N2 = resolver.getResolvedPath().get(1).getEntity();
     PolarisBaseEntity T1 = resolver.getResolvedPath().get(2).getEntity();
 
@@ -494,8 +494,11 @@ public class ResolverTest {
     principalRolesResolved.sort(Comparator.comparing(p -> p.getEntity().getName()));
 
     // ensure they are PR1 and PR2
-    this.ensureResolved(principalRolesResolved.getFirst(), PolarisEntityType.PRINCIPAL_ROLE, "PR1");
-    this.ensureResolved(principalRolesResolved.getLast(), PolarisEntityType.PRINCIPAL_ROLE, "PR2");
+    this.ensureResolved(principalRolesResolved.get(0), PolarisEntityType.PRINCIPAL_ROLE, "PR1");
+    this.ensureResolved(
+        principalRolesResolved.get(principalRolesResolved.size() - 1),
+        PolarisEntityType.PRINCIPAL_ROLE,
+        "PR2");
 
     // if a principal role was passed-in, ensure it exists
     if (principalRoleName != null) {

--- a/polaris-core/src/test/java/io/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/io/polaris/service/storage/aws/AwsCredentialsStorageIntegrationTest.java
@@ -96,13 +96,21 @@ class AwsCredentialsStorageIntegrationTest {
   public void testGetSubscopedCredsInlinePolicy(String awsPartition) {
     PolarisStorageConfigurationInfo.StorageType storageType =
         PolarisStorageConfigurationInfo.StorageType.S3;
-    String roleARN =
-        switch (awsPartition) {
-          case AWS_PARTITION -> "arn:aws:iam::012345678901:role/jdoe";
-          case "aws-cn" -> "arn:aws-cn:iam::012345678901:role/jdoe";
-          case "aws-us-gov" -> "arn:aws-us-gov:iam::012345678901:role/jdoe";
-          default -> throw new IllegalArgumentException("Unknown aws partition: " + awsPartition);
-        };
+    String roleARN;
+    switch (awsPartition) {
+      case AWS_PARTITION:
+        roleARN = "arn:aws:iam::012345678901:role/jdoe";
+        break;
+      case "aws-cn":
+        roleARN = "arn:aws-cn:iam::012345678901:role/jdoe";
+        break;
+      case "aws-us-gov":
+        roleARN = "arn:aws-us-gov:iam::012345678901:role/jdoe";
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown aws partition: " + awsPartition);
+    }
+    ;
     StsClient stsClient = Mockito.mock(StsClient.class);
     String externalId = "externalId";
     String bucket = "bucket";

--- a/polaris-core/src/test/java/io/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
+++ b/polaris-core/src/test/java/io/polaris/service/storage/gcp/GcpCredentialsStorageIntegrationTest.java
@@ -200,30 +200,8 @@ class GcpCredentialsStorageIntegrationTest {
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules =
         mapper.readTree(
-            """
-{
-  "accessBoundaryRules": [
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('path/to/data')"
-      }
-    },
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectCreator"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
-      }
-    }
-  ]
-}
-                """);
+            GcpCredentialsStorageIntegrationTest.class.getResource(
+                "gcp-testGenerateAccessBoundary.json"));
     assertThat(parsedRules)
         .usingRecursiveComparison(
             RecursiveComparisonConfiguration.builder()
@@ -256,39 +234,8 @@ class GcpCredentialsStorageIntegrationTest {
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules =
         mapper.readTree(
-            """
-{
-  "accessBoundaryRules": [
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data')"
-      }
-    },
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket2",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket2/objects/a/super/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('a/super/path/to/data')"
-      }
-    },
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectCreator"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
-      }
-    }
-  ]
-}
-                """);
+            GcpCredentialsStorageIntegrationTest.class.getResource(
+                "gcp-testGenerateAccessBoundaryWithMultipleBuckets.json"));
     assertThat(parsedRules)
         .usingRecursiveComparison(
             RecursiveComparisonConfiguration.builder()
@@ -318,30 +265,8 @@ class GcpCredentialsStorageIntegrationTest {
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules =
         mapper.readTree(
-            """
-{
-  "accessBoundaryRules": [
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/another/path/to/data')"
-      }
-    },
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectCreator"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
-      }
-    }
-  ]
-}
-            """);
+            GcpCredentialsStorageIntegrationTest.class.getResource(
+                "gcp-testGenerateAccessBoundaryWithoutList.json"));
     assertThat(parsedRules)
         .usingRecursiveComparison(
             RecursiveComparisonConfiguration.builder()
@@ -371,21 +296,8 @@ class GcpCredentialsStorageIntegrationTest {
     JsonNode parsedRules = mapper.convertValue(credentialAccessBoundary, JsonNode.class);
     JsonNode refRules =
         mapper.readTree(
-            """
-{
-  "accessBoundaryRules": [
-    {
-      "availablePermissions": [
-        "inRole:roles/storage.objectViewer"
-      ],
-      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
-      "availabilityCondition": {
-        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data')"
-      }
-    }
-  ]
-}
-            """);
+            GcpCredentialsStorageIntegrationTest.class.getResource(
+                "gcp-testGenerateAccessBoundaryWithoutWrites.json"));
     assertThat(parsedRules)
         .usingRecursiveComparison(
             RecursiveComparisonConfiguration.builder()

--- a/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundary.json
+++ b/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundary.json
@@ -1,0 +1,22 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('path/to/data')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectCreator"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
+      }
+    }
+  ]
+}

--- a/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundaryWithMultipleBuckets.json
+++ b/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundaryWithMultipleBuckets.json
@@ -1,0 +1,31 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket2",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket2/objects/a/super/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('a/super/path/to/data')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectCreator"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
+      }
+    }
+  ]
+}

--- a/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundaryWithoutList.json
+++ b/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundaryWithoutList.json
@@ -1,0 +1,22 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/another/path/to/data')"
+      }
+    },
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectCreator"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/path/to/data')"
+      }
+    }
+  ]
+}

--- a/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundaryWithoutWrites.json
+++ b/polaris-core/src/test/resources/io/polaris/service/storage/gcp/gcp-testGenerateAccessBoundaryWithoutWrites.json
@@ -1,0 +1,13 @@
+{
+  "accessBoundaryRules": [
+    {
+      "availablePermissions": [
+        "inRole:roles/storage.objectViewer"
+      ],
+      "availableResource": "//storage.googleapis.com/projects/_/buckets/bucket1",
+      "availabilityCondition": {
+        "expression": "resource.name.startsWith('projects/_/buckets/bucket1/objects/normal/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('normal/path/to/data') || resource.name.startsWith('projects/_/buckets/bucket1/objects/awesome/path/to/data') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('awesome/path/to/data')"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
According to the discussion #100, this change enforces Java release 21 for server code and 11 for client consumable code.

Using Java 11 requires some changes to `:polaris-core`. One new BSD-3-Clause licensed test dependency `org.threeten:threeten-extra` was added to provide a mutable clock to replace `java.time.InstantSource`.

Fixes #76
Discussed in #100
