### PR TITLE
Rename setup.sh to run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Running in Docker
 - `docker compose up --build --exit-code-from regtest` - To run regression tests in a Docker environment.
 
 Running in Kubernetes
-- `./setup.sh` - To run Polaris as a mini-deployment locally. This will create two pods that bind themselves to port `8181`.
+- `./run.sh` - To run Polaris as a mini-deployment locally. This will create two pods that bind themselves to port `8181`.
 - `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster.
 - `kubectl get pods -n polaris` - To check the status of the pods.
 - `kubectl get deployment -n polaris` - To check the status of the deployment.

--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+# Runs Polaris as a mini-deployment locally. Creates two pods that bind themselves to port 8181.
+
 CURRENT_DIR=$(pwd)
 
 # deploy the registry


### PR DESCRIPTION
"setup" can be misunderstood as build-related. Rename the script to avoid confusion. Also add a line of comment what the script does for readers who didn't read (or didn't remember) all of the README.

