### PR TITLE
Reduce k8s deployment replica and add metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ Running in Docker
 
 Running in Kubernetes
 - `./setup.sh` - To run Polaris as a mini-deployment locally. This will create one pod that bind itself to ports `8181` and `8182`.
-- `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster for service endpoints.
-- `kubectl port-forward svc/polaris-service -n polaris 8182:8182` - To create a secure connection between a local machine and a pod within the cluster for metrics endpoints.
-  - Currrently supported endpoints:
+- `kubectl port-forward svc/polaris-service -n polaris 8181:8181 8182:8182` - To create secure connections between a local machine and a pod within the cluster for both service and metrics endpoints.
+  - Currrently supported metrics endpoints:
     - localhost:8182/metrics
     - localhost:8182/healthcheck
 - `kubectl get pods -n polaris` - To check the status of the pods.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Running in Kubernetes
 - `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster for service endpoints.
 - `kubectl port-forward svc/polaris-service -n polaris 8182:8182` - To create a secure connection between a local machine and a pod within the cluster for metrics endpoints.
   - Currrently supported endpoints:
-    - localhost:8182/jmx
     - localhost:8182/metrics
+    - localhost:8182/healthcheck
 - `kubectl get pods -n polaris` - To check the status of the pods.
 - `kubectl get deployment -n polaris` - To check the status of the deployment.
 - `kubectl describe deployment polaris-deployment -n polaris` - To troubleshoot if things aren't working as expected.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ Running in Docker
 - `docker compose up --build --exit-code-from regtest` - To run regression tests in a Docker environment.
 
 Running in Kubernetes
-- `./setup.sh` - To run Polaris as a mini-deployment locally. This will create two pods that bind themselves to port `8181`.
-- `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster.
+- `./setup.sh` - To run Polaris as a mini-deployment locally. This will create one pod that bind itself to ports `8181` and `8182`.
+- `kubectl port-forward svc/polaris-service -n polaris 8181:8181` - To create a secure connection between a local machine and a pod within the cluster for service endpoints.
+- `kubectl port-forward svc/polaris-service -n polaris 8182:8182` - To create a secure connection between a local machine and a pod within the cluster for metrics endpoints.
+  - Currrently supported endpoints:
+    - localhost:8182/jmx
+    - localhost:8182/metrics
 - `kubectl get pods -n polaris` - To check the status of the pods.
 - `kubectl get deployment -n polaris` - To check the status of the deployment.
 - `kubectl describe deployment polaris-deployment -n polaris` - To troubleshoot if things aren't working as expected.

--- a/k8/deployment.yaml
+++ b/k8/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   name: polaris-deployment
   namespace: polaris
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: polaris

--- a/k8/deployment.yaml
+++ b/k8/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
   name: polaris-deployment
   namespace: polaris
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: polaris
@@ -23,6 +22,7 @@ spec:
         image: localhost:5001/polaris:latest
         ports:
         - containerPort: 8181
+        - containerPort: 8182
 ---
 apiVersion: v1
 kind: Service
@@ -33,5 +33,9 @@ spec:
   selector:
     app: polaris
   ports:
-  - port: 8181
+  - name: service
+    port: 8181
     targetPort: 8181
+  - name: metrics
+    port: 8182
+    targetPort: 8182


### PR DESCRIPTION
# Description

With the original README.md, it indicated the k8s manifest will spin up 2 pods and we will have k8s svc on top. However, this is bad as the default backend metastore is in-memory. Thus, each pod will have their own credential thus the svc became unpredictable (unless we want to do headless one then have user point to each pod implicitly). Thus I reduced the replica to 1 and updated the doc to reflect the same. Along with that, I exposed one more port (8182) that is supported by the catalog to expose jmx metrics as well as healthcheck endpoint. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

```sh
# Port forward for 8182 for metrics endpoints
kubectl port-forward svc/polaris-service -n polaris 8182:8182

# Show healthcheck endpoint
$ curl -s localhost:8182/healthcheck | jq
{
  "deadlocks": {
    "healthy": true,
    "duration": 0,
    "timestamp": "2024-08-08T23:16:11.064Z"
  },
  "polaris": {
    "healthy": true,
    "duration": 0,
    "timestamp": "2024-08-08T23:16:11.063Z"
  }
}

# Show JMX endpoint
$ curl -s localhost:8182/metrics | head
# HELP polaris_CatalogApi_commitTransaction_count_total
# TYPE polaris_CatalogApi_commitTransaction_count_total counter
polaris_CatalogApi_commitTransaction_count_total 0.0
# HELP polaris_CatalogApi_commitTransaction_error_total
# TYPE polaris_CatalogApi_commitTransaction_error_total counter
polaris_CatalogApi_commitTransaction_error_total{HTTP_RESPONSE_CODE="400"} 0.0
polaris_CatalogApi_commitTransaction_error_total{HTTP_RESPONSE_CODE="500"} 0.0
# HELP polaris_CatalogApi_commitTransaction_seconds
# TYPE polaris_CatalogApi_commitTransaction_seconds summary
polaris_CatalogApi_commitTransaction_seconds_count 0
```

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
- [x] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
