### PR TITLE
Exclude the dir polaris-venv to avoid rat failure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,8 @@ tasks.named<RatTask>("rat").configure {
   excludes.add("polaris-service/src/**/banner.txt")
   excludes.add("polaris-service/logs")
 
+  excludes.add("**/polaris-venv/**")
+
   excludes.add("regtests/**/py.typed")
   excludes.add("regtests/**/*.ref")
   excludes.add("regtests/client/python/.openapi-generator/**")


### PR DESCRIPTION
# Description

Polaris cli will generate a dir named `polaris-venv`, which fails the RAT check. We need to exclude it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

The command `./gradlew build` passed after the fix

# Checklist:

- [x] I have performed a self-review of my code
