### PR TITLE
Assert on expected exception's message

### DIFF
--- a/polaris-core/src/test/java/io/polaris/core/storage/cache/StorageCredentialCacheTest.java
+++ b/polaris-core/src/test/java/io/polaris/core/storage/cache/StorageCredentialCacheTest.java
@@ -37,6 +37,7 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.RepeatedTest;
@@ -94,7 +95,8 @@ public class StorageCredentialCacheTest {
                     true,
                     new HashSet<>(Arrays.asList("s3://bucket1/path")),
                     new HashSet<>(Arrays.asList("s3://bucket3/path"))))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(UnprocessableEntityException.class)
+        .hasMessage("Failed to get subscoped credentials: extra_error_info");
   }
 
   @Test

--- a/polaris-service/src/test/java/io/polaris/service/PolarisApplicationIntegrationTest.java
+++ b/polaris-service/src/test/java/io/polaris/service/PolarisApplicationIntegrationTest.java
@@ -308,7 +308,9 @@ public class PolarisApplicationIntegrationTest {
   @Test
   public void testConfigureCatalogCaseSensitive() throws IOException {
     assertThatThrownBy(() -> newSessionCatalog("TESTCONFIGURECATALOGCASESENSITIVE"))
-        .isInstanceOf(RESTException.class);
+        .isInstanceOf(RESTException.class)
+        .hasMessage(
+            "Unable to process: Unable to find warehouse TESTCONFIGURECATALOGCASESENSITIVE");
   }
 
   @Test
@@ -318,7 +320,8 @@ public class PolarisApplicationIntegrationTest {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
       assertThatThrownBy(
               () -> sessionCatalog.listNamespaces(sessionContext, Namespace.of("whoops")))
-          .isInstanceOf(NoSuchNamespaceException.class);
+          .isInstanceOf(NoSuchNamespaceException.class)
+          .hasMessage("Namespace does not exist: whoops");
     }
   }
 
@@ -334,7 +337,8 @@ public class PolarisApplicationIntegrationTest {
               () ->
                   sessionCatalog.listNamespaces(
                       sessionContext, Namespace.of("top_level", "whoops")))
-          .isInstanceOf(NoSuchNamespaceException.class);
+          .isInstanceOf(NoSuchNamespaceException.class)
+          .hasMessage("Namespace does not exist: top_level.whoops");
     }
   }
 
@@ -344,7 +348,8 @@ public class PolarisApplicationIntegrationTest {
         newSessionCatalog("testIcebergListTablesNamespaceNotFound")) {
       SessionCatalog.SessionContext sessionContext = SessionCatalog.SessionContext.createEmpty();
       assertThatThrownBy(() -> sessionCatalog.listTables(sessionContext, Namespace.of("whoops")))
-          .isInstanceOf(NoSuchNamespaceException.class);
+          .isInstanceOf(NoSuchNamespaceException.class)
+          .hasMessage("Namespace does not exist: whoops");
     }
   }
 
@@ -394,7 +399,8 @@ public class PolarisApplicationIntegrationTest {
       assertThat(namespaces).isNotNull().hasSize(1).containsExactly(ns);
       sessionCatalog.dropNamespace(sessionContext, ns);
       assertThatThrownBy(() -> sessionCatalog.loadNamespaceMetadata(sessionContext, ns))
-          .isInstanceOf(NoSuchNamespaceException.class);
+          .isInstanceOf(NoSuchNamespaceException.class)
+          .hasMessage("Namespace does not exist: db1");
     }
   }
 
@@ -420,7 +426,8 @@ public class PolarisApplicationIntegrationTest {
                       .withSortOrder(SortOrder.unsorted())
                       .withPartitionSpec(PartitionSpec.unpartitioned())
                       .create())
-          .isInstanceOf(BadRequestException.class);
+          .isInstanceOf(BadRequestException.class)
+          .hasMessage("Malformed request: Cannot create table on external catalogs.");
     }
   }
 
@@ -570,7 +577,8 @@ public class PolarisApplicationIntegrationTest {
                               new PartitionData(PartitionSpec.unpartitioned().partitionType()),
                               10L))
                       .commit())
-          .isInstanceOf(BadRequestException.class);
+          .isInstanceOf(BadRequestException.class)
+          .hasMessage("Malformed request: Cannot update table on external catalogs.");
     }
   }
 
@@ -614,7 +622,8 @@ public class PolarisApplicationIntegrationTest {
       assertThat(table).isNotNull();
       sessionCatalog.dropTable(sessionContext, tableIdentifier);
       assertThatThrownBy(() -> sessionCatalog.loadTable(sessionContext, tableIdentifier))
-          .isInstanceOf(NoSuchTableException.class);
+          .isInstanceOf(NoSuchTableException.class)
+          .hasMessage("Table does not exist: db1.the_table");
     }
   }
 
@@ -638,7 +647,8 @@ public class PolarisApplicationIntegrationTest {
                           emptyEnvironmentVariable,
                           "header." + REALM_PROPERTY_KEY,
                           realm)))
-          .isInstanceOf(BadRequestException.class);
+          .isInstanceOf(BadRequestException.class)
+          .hasMessage("Malformed request: Please specify a warehouse");
     }
   }
 }


### PR DESCRIPTION
It's useful to assert on the test's expected exception's message to verify

- that the exception is indeed the one being expected (and not some different exception of the same class),
- that the user-visible error message is understandable.
