### PR TITLE
CLI should pass through GCS service account

### DIFF
--- a/regtests/client/python/cli/command/catalogs.py
+++ b/regtests/client/python/cli/command/catalogs.py
@@ -126,8 +126,7 @@ class CatalogsCommand(Command):
             config = GcpStorageConfigInfo(
                 storage_type=self.storage_type.upper(),
                 allowed_locations=self.allowed_locations,
-                tenant_id=self.tenant_id,
-                multi_tenant_app_name=self.multi_tenant_app_name
+                gcs_service_account=self.service_account
             )
         elif self.storage_type == StorageType.FILE.value:
             config = StorageConfigInfo(

--- a/regtests/client/python/test/test_cli_parsing.py
+++ b/regtests/client/python/test/test_cli_parsing.py
@@ -218,6 +218,18 @@ class TestCliParsing(unittest.TestCase):
                 (0, 'catalog.properties.default_base_location'): 'x',
                 (0, 'catalog.storage_config_info.allowed_locations'): ['a', 'b'],
             })
+        check_arguments(
+            mock_execute([
+                'catalogs', 'create', 'my-catalog', '--storage-type', 'gcs',
+                '--allowed-location', 'a', '--allowed-location', 'b',
+                '--service-account', 'sa', '--default-base-location', 'x']),
+            'create_catalog', {
+                (0, 'catalog.name'): 'my-catalog',
+                (0, 'catalog.storage_config_info.storage_type'): 'GCS',
+                (0, 'catalog.properties.default_base_location'): 'x',
+                (0, 'catalog.storage_config_info.allowed_locations'): ['a', 'b'],
+                (0, 'catalog.storage_config_info.gcs_service_account'): 'sa',
+            })
         check_arguments(mock_execute(['catalogs', 'list']), 'list_catalogs')
         check_arguments(mock_execute(['catalogs', 'delete', 'foo']), 'delete_catalog', {
             (0, None): 'foo',


### PR DESCRIPTION
# Description

When using the `gcs` storage type, the CLI should correctly use the `storage-account` option instead of `tenant-id` and `multi-tenant-app-name`.

Fixes #133 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added a test to `test_cli_parsing.py`

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed and submitted the [ICLA](https://github.com/polaris-catalog/polaris/blob/main/ICLA.md) and if needed, the [CCLA](https://github.com/polaris-catalog/polaris/blob/main/CCLA.md). See [Contributing](https://github.com/polaris-catalog/polaris/blob/main/CONTRIBUTING.md) for details. 
